### PR TITLE
винесення DateTime.Now в IDateTimeProvider

### DIFF
--- a/CaloriesTracker/Program.cs
+++ b/CaloriesTracker/Program.cs
@@ -36,6 +36,8 @@ builder.Services.AddScoped<CalorieService>();
 builder.Services.AddScoped<ReportService>();
 builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<ICalorieCalculatorService, CalorieCalculatorService>();
+builder.Services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
+builder.Services.AddScoped<CalorieService>();
 
 builder.Services.AddControllersWithViews();
 

--- a/CaloriesTracker/Services/CalorieService.cs
+++ b/CaloriesTracker/Services/CalorieService.cs
@@ -5,137 +5,167 @@ using Microsoft.EntityFrameworkCore;
 
 namespace CaloriesTracker.Services
 {
-    public class CalorieService
-    {
-        private readonly AppDbContext _context;
-
-        public CalorieService(AppDbContext context)
+        // Інтерфейс для отримання поточного часу (для кращої тестованості)
+        public interface IDateTimeProvider
         {
-            _context = context;
+            DateTime Now { get; }
         }
 
-        public async Task<DailyIntake> AddDailyIntakeAsync(int productId, decimal quantity, string userId)
+        // Реалізація інтерфейсу за замовчуванням — повертає системний час
+        public class SystemDateTimeProvider : IDateTimeProvider
         {
-            var intake = new DailyIntake
-            {
-                ProductId = productId,
-                Quantity = quantity,
-                UserId = userId,
-                Date = DateTime.Now
-            };
-
-            _context.DailyIntakes.Add(intake);
-            await _context.SaveChangesAsync();
-            return intake;
+            public DateTime Now => DateTime.Now;
         }
 
-        public async Task<bool> RemoveDailyIntakeAsync(int intakeId, string userId)
+        public class CalorieService
         {
-            var intake = await _context.DailyIntakes
-                .FirstOrDefaultAsync(d => d.Id == intakeId && d.UserId == userId);
+            private readonly AppDbContext _context;
+            private readonly IDateTimeProvider _dateTimeProvider;
 
-            if (intake == null) return false;
-
-            _context.DailyIntakes.Remove(intake);
-            await _context.SaveChangesAsync();
-            return true;
-        }
-
-        public async Task<DailySummary> GetDailySummaryAsync(string userId, DateTime date)
-        {
-            var intakes = await _context.DailyIntakes
-                .Include(d => d.Product)
-                .Where(d => d.UserId == userId && d.Date.Date == date.Date)
-                .ToListAsync();
-
-            var user = await _context.Users.FindAsync(userId);
-
-            var summary = new DailySummary
+            public CalorieService(AppDbContext context, IDateTimeProvider dateTimeProvider)
             {
-                Date = date,
-                TotalCalories = intakes.Sum(i => i.Product.CaloriesPer100g * i.Quantity / 100),
-                TotalProtein = intakes.Sum(i => i.Product.ProteinPer100g * i.Quantity / 100),
-                TotalFat = intakes.Sum(i => i.Product.FatPer100g * i.Quantity / 100),
-                TotalCarbs = intakes.Sum(i => i.Product.CarbsPer100g * i.Quantity / 100),
-                DailyGoal = user?.DailyCalorieGoal ?? 2000,
-                Intakes = intakes
-            };
+                _context = context;
+                _dateTimeProvider = dateTimeProvider;
+            }
 
-            return summary;
-        }
+            // Приватні методи для обчислення нутрієнтів
+            private static decimal CalculateCalories(Product product, decimal quantity)
+                => product.CaloriesPer100g * quantity / 100;
 
-        public async Task<UserStats> GetUserStatsAsync(string userId, DateTime startDate, DateTime endDate)
-        {
-            var intakes = await _context.DailyIntakes
-                .Include(d => d.Product)
-                .Where(d => d.UserId == userId && d.Date >= startDate && d.Date <= endDate)
-                .OrderBy(d => d.Date)
-                .ToListAsync();
+            private static decimal CalculateProtein(Product product, decimal quantity)
+                => product.ProteinPer100g * quantity / 100;
 
-            var stats = new UserStats
+            private static decimal CalculateFat(Product product, decimal quantity)
+                => product.FatPer100g * quantity / 100;
+
+            private static decimal CalculateCarbs(Product product, decimal quantity)
+                => product.CarbsPer100g * quantity / 100;
+
+            public async Task<DailyIntake> AddDailyIntakeAsync(int productId, decimal quantity, string userId)
             {
-                TotalCalories = intakes.Sum(i => i.Product.CaloriesPer100g * i.Quantity / 100),
-                TotalProtein = intakes.Sum(i => i.Product.ProteinPer100g * i.Quantity / 100),
-                TotalFat = intakes.Sum(i => i.Product.FatPer100g * i.Quantity / 100),
-                TotalCarbs = intakes.Sum(i => i.Product.CarbsPer100g * i.Quantity / 100),
-                DaysTracked = intakes.Select(i => i.Date.Date).Distinct().Count(),
-                PeriodName = $"{startDate:dd.MM.yyyy} - {endDate:dd.MM.yyyy}"
-            };
-
-            stats.AverageDailyCalories = intakes.Any()
-                ? intakes.GroupBy(i => i.Date.Date)
-                         .Average(g => g.Sum(i => i.Product.CaloriesPer100g * i.Quantity / 100))
-                : 0;
-
-            if (intakes.Any())
-            {
-                stats.CalorieTrendData = intakes
-                    .GroupBy(i => i.Date.Date)
-                    .OrderBy(g => g.Key)
-                    .Select(g => new CalorieTrendPoint
-                    {
-                        Date = g.Key,
-                        Calories = g.Sum(i => i.Product.CaloriesPer100g * i.Quantity / 100)
-                    })
-                    .ToList();
-
-                stats.MacroNutrientsData = new MacroNutrients
+                var intake = new DailyIntake
                 {
-                    Protein = stats.TotalProtein,
-                    Fat = stats.TotalFat,
-                    Carbs = stats.TotalCarbs
+                    ProductId = productId,
+                    Quantity = quantity,
+                    UserId = userId,
+                    Date = _dateTimeProvider.Now
+                };
+
+                _context.DailyIntakes.Add(intake);
+                await _context.SaveChangesAsync();
+                return intake;
+            }
+
+            public async Task<bool> RemoveDailyIntakeAsync(int intakeId, string userId)
+            {
+                var intake = await _context.DailyIntakes
+                    .FirstOrDefaultAsync(d => d.Id == intakeId && d.UserId == userId);
+
+                if (intake == null) return false;
+
+                _context.DailyIntakes.Remove(intake);
+                await _context.SaveChangesAsync();
+                return true;
+            }
+
+            public async Task<DailySummary> GetDailySummaryAsync(string userId, DateTime date)
+            {
+                var intakes = await _context.DailyIntakes
+                    .Include(d => d.Product)
+                    .Where(d => d.UserId == userId && d.Date.Date == date.Date)
+                    .ToListAsync();
+
+                var user = await _context.Users.FindAsync(userId);
+
+                var totalCalories = intakes.Sum(i => CalculateCalories(i.Product, i.Quantity));
+                var totalProtein = intakes.Sum(i => CalculateProtein(i.Product, i.Quantity));
+                var totalFat = intakes.Sum(i => CalculateFat(i.Product, i.Quantity));
+                var totalCarbs = intakes.Sum(i => CalculateCarbs(i.Product, i.Quantity));
+
+                return new DailySummary
+                {
+                    Date = date,
+                    TotalCalories = totalCalories,
+                    TotalProtein = totalProtein,
+                    TotalFat = totalFat,
+                    TotalCarbs = totalCarbs,
+                    DailyGoal = user?.DailyCalorieGoal ?? 2000,
+                    Intakes = intakes
                 };
             }
 
-            return stats;
-        }
-
-        public async Task<DailyIntake> AddDailyIntakeWithDateAsync(int productId, decimal quantity, string userId, DateTime date)
-        {
-            var intake = new DailyIntake
+            public async Task<UserStats> GetUserStatsAsync(string userId, DateTime startDate, DateTime endDate)
             {
-                ProductId = productId,
-                Quantity = quantity,
-                UserId = userId,
-                Date = date
-            };
+                var intakes = await _context.DailyIntakes
+                    .Include(d => d.Product)
+                    .Where(d => d.UserId == userId && d.Date >= startDate && d.Date <= endDate)
+                    .OrderBy(d => d.Date)
+                    .ToListAsync();
 
-            _context.DailyIntakes.Add(intake);
-            await _context.SaveChangesAsync();
-            return intake;
-        }
+                var stats = new UserStats
+                {
+                    TotalCalories = intakes.Sum(i => CalculateCalories(i.Product, i.Quantity)),
+                    TotalProtein = intakes.Sum(i => CalculateProtein(i.Product, i.Quantity)),
+                    TotalFat = intakes.Sum(i => CalculateFat(i.Product, i.Quantity)),
+                    TotalCarbs = intakes.Sum(i => CalculateCarbs(i.Product, i.Quantity)),
+                    DaysTracked = intakes.Select(i => i.Date.Date).Distinct().Count(),
+                    PeriodName = $"{startDate:dd.MM.yyyy} - {endDate:dd.MM.yyyy}"
+                };
 
-        public async Task<bool> UpdateIntakeQuantityAsync(int intakeId, decimal newQuantity, string userId)
-        {
-            var intake = await _context.DailyIntakes
-                .FirstOrDefaultAsync(i => i.Id == intakeId && i.UserId == userId);
+                stats.AverageDailyCalories = intakes.Any()
+                    ? intakes.GroupBy(i => i.Date.Date)
+                             .Average(g => g.Sum(i => CalculateCalories(i.Product, i.Quantity)))
+                    : 0;
 
-            if (intake == null) return false;
+                if (intakes.Any())
+                {
+                    stats.CalorieTrendData = intakes
+                        .GroupBy(i => i.Date.Date)
+                        .OrderBy(g => g.Key)
+                        .Select(g => new CalorieTrendPoint
+                        {
+                            Date = g.Key,
+                            Calories = g.Sum(i => CalculateCalories(i.Product, i.Quantity))
+                        })
+                        .ToList();
 
-            intake.Quantity = newQuantity;
-            intake.Date = DateTime.Now;
-            await _context.SaveChangesAsync();
-            return true;
+                    stats.MacroNutrientsData = new MacroNutrients
+                    {
+                        Protein = stats.TotalProtein,
+                        Fat = stats.TotalFat,
+                        Carbs = stats.TotalCarbs
+                    };
+                }
+
+                return stats;
+            }
+
+            public async Task<DailyIntake> AddDailyIntakeWithDateAsync(int productId, decimal quantity, string userId, DateTime date)
+            {
+                var intake = new DailyIntake
+                {
+                    ProductId = productId,
+                    Quantity = quantity,
+                    UserId = userId,
+                    Date = date
+                };
+
+                _context.DailyIntakes.Add(intake);
+                await _context.SaveChangesAsync();
+                return intake;
+            }
+
+            public async Task<bool> UpdateIntakeQuantityAsync(int intakeId, decimal newQuantity, string userId)
+            {
+                var intake = await _context.DailyIntakes
+                    .FirstOrDefaultAsync(i => i.Id == intakeId && i.UserId == userId);
+
+                if (intake == null) return false;
+
+                intake.Quantity = newQuantity;
+                intake.Date = _dateTimeProvider.Now;
+                await _context.SaveChangesAsync();
+                return true;
+            }
         }
     }
-}


### PR DESCRIPTION
**Опис проблеми**
На поточний момент у класі [`CalorieService`](https://github.com/nkhmnk/CaloriesTracker/blob/my-feature-branch/CaloriesTracker/Services/CalorieService.cs) використовується прямий виклик `DateTime.Now`. Це створює жорстке зв'язування з системним часом, що:
- ускладнює тестування;
- зменшує гнучкість коду;
- порушує принципи чистої архітектури (зокрема, Принцип інверсії залежностей).

**Запропоноване рішення**
Для усунення цієї проблеми було додано інтерфейс [`IDateTimeProvider`](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L9), який надає доступ до поточної дати та часу через властивість Now.
Також створено реалізацію цього інтерфейсу — [`SystemDateTimeProvider`](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L15), яка повертає значення DateTime.Now.
Клас [`CalorieService`](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L20) та всі інші, що залежать від дати, оновлено для використання цього інтерфейсу через впровадження залежностей (dependency injection).

**Переваги**
- Код став легше тестувати — можна підставляти фейковий час у тестах.
- Підвищено гнучкість і підтримуваність.
- Усунуто “запах коду” — жорстка прив'язка до системного часу.
- Функціональність програми не змінилася, лише покращено структуру.

**Основні зміни**
- Додано [`IDateTimeProvider`](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L9).
- Додано [`SystemDateTimeProvider`](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L15).
- Оновлено [`CalorieService`](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L20), щоб використовував [_dateTimeProvider.Now](https://github.com/nkhmnk/CaloriesTracker/blob/55dca92407e72e966a98f4cb6cefbd9f359da506/CaloriesTracker/Services/CalorieService.cs#L23) замість DateTime.Now.
- Зареєстровано залежність у DI-контейнері в [`Program.cs`](https://github.com/nkhmnk/CaloriesTracker/blob/my-feature-branch/CaloriesTracker/Program.cs):

> builder.Services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();